### PR TITLE
PHP 8.4.15

### DIFF
--- a/versions/8.4.15-fpm/Dockerfile
+++ b/versions/8.4.15-fpm/Dockerfile
@@ -1,0 +1,71 @@
+FROM surnet/alpine-wkhtmltopdf:3.19.0-0.12.6-full as wkhtmltopdf
+
+FROM php:8.4.15-fpm-alpine
+
+ENV S6_LOGGING=1 S6_OVERLAY_VERSION=1.19.1.1 GODNSMASQ_VERSION=1.0.7 CONSUL_TEMPLATE_VERSION=0.32.0 CONSUL_VERSION=1.15.0 MEMCACHED_DEPS="zlib-dev libmemcached-dev cyrus-sasl-dev" TZ="America/New_York"
+
+# Download architecture-specific binaries (newer versions with ARM64 support)
+RUN apk add --no-cache unzip && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then CONSUL_ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then CONSUL_ARCH="arm64"; \
+    else CONSUL_ARCH="amd64"; fi && \
+    # Download consul
+    wget -O /tmp/consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_${CONSUL_ARCH}.zip && \
+    unzip /tmp/consul.zip -d /usr/local/bin && \
+    rm /tmp/consul.zip && \
+    # Download consul-template
+    wget -O /tmp/consul-template.zip https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_${CONSUL_ARCH}.zip && \
+    unzip /tmp/consul-template.zip -d /usr/local/bin && \
+    rm /tmp/consul-template.zip && \
+    chmod +x /usr/local/bin/consul /usr/local/bin/consul-template && \
+    apk del unzip
+
+# Copy s6 overlay configs (these are just scripts, not binaries)
+RUN mkdir -p /etc/cont-init.d /etc/services.d /root
+
+RUN apk update && apk upgrade \
+    && apk add --no-cache \
+      coreutils \
+      freetype-dev \
+      libjpeg-turbo-dev \
+      libtool \
+      libpng-dev \
+      curl wget bash tree jq bind-tools build-base gcc autoconf \
+      zlib \
+      libmemcached-dev \
+      cyrus-sasl-dev \
+      zlib-dev \
+      linux-headers \
+      $PHPIZE_DEPS \
+    && pecl install memcached-3.3.0 \
+    && docker-php-ext-enable memcached \
+    && pecl install memcache \
+    && docker-php-ext-enable memcache \
+    && docker-php-ext-install mysqli \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd \
+    && docker-php-ext-install bcmath \
+    && rm -rf /tmp/pear
+
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then S6_ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then S6_ARCH="aarch64"; \
+    else S6_ARCH="amd64"; fi && \
+    curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.gz | tar -xz -C /
+
+# Install Composer - disable xdebug during build
+RUN XDEBUG_MODE=off curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+
+RUN echo $TZ > /etc/timezone \
+    && touch /usr/local/var/run/php-fpm.pid \
+    && echo -ne "- with $(php -v | head -n 1)\n" >> /root/.built
+
+EXPOSE 9000
+
+# Workaround https://bugs.php.net/bug.php?id=71880
+ENV LOG_STREAM="/tmp/stdout"
+RUN mkfifo $LOG_STREAM && chmod 777 $LOG_STREAM
+
+ENTRYPOINT ["/init"]
+CMD ["/bin/sh", "-c", "/usr/local/sbin/php-fpm --pid /usr/local/var/run/php-fpm.pid | tail -f $LOG_STREAM"]

--- a/versions/8.4.15-fpm/Dockerfile-tests
+++ b/versions/8.4.15-fpm/Dockerfile-tests
@@ -1,0 +1,18 @@
+FROM bandsintown/php:8.4.15-fpm
+
+ENV BATS_VERSION=0.4.0 DOCKERIZE_VERSION=v0.2.0
+
+COPY tests /tests
+WORKDIR /tests
+
+RUN exec 2>&1 && apk add --update bind-tools bc jq \
+    && curl -Ls https://codeload.github.com/sstephenson/bats/zip/v$BATS_VERSION -o /tmp/bats.zip \
+	&& cd /tmp \
+	&& unzip -q bats.zip \
+	&& ./bats-${BATS_VERSION}/install.sh /usr/local \
+	&& ln -sf /usr/local/libexec/bats /usr/local/bin/bats \
+    && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+	&& rm -f bats.zip dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+CMD ["bash"]


### PR DESCRIPTION
It will be used for Promoter since 8.1.2 is no longer security supported. The 8.3 will end in a year and 8.4 will end in almost 3 years. 8.5 is too early to use.

I put this Dockerfile content in [Promoter repo](https://github.com/bandsintown/Promoter/blob/php-update-2026/build/application/Dockerfile) for testing and deployed to [Staging](https://promoters.stg.bandsintown.com/) and looks good to me.

My understanding is that the best practice is to put in this repo and I assume it will be uploaded in Dockerhub (not sure how that part works). I can then only replace this content by "FROM bandsintown/php:8.4.15-fpm" in the Promoter repo Dockerfile.

Thanks.